### PR TITLE
Add basic Jest tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/__tests__/AddBuildingButton.test.js
+++ b/__tests__/AddBuildingButton.test.js
@@ -1,0 +1,12 @@
+import {addBuilding} from '../src/utils/gameActions';
+import SIZE_PRESETS from '../src/constants/sizePresets';
+
+describe('addBuilding', () => {
+  it('adds a building and deducts money', () => {
+    const state = {money: 5000, buildings: []};
+    const newState = addBuilding(state, SIZE_PRESETS[0]);
+    expect(newState.money).toBe(state.money - SIZE_PRESETS[0].purchaseCost);
+    expect(newState.buildings).toHaveLength(1);
+    expect(newState.buildings[0].size).toEqual(SIZE_PRESETS[0]);
+  });
+});

--- a/__tests__/BuildingDetail.test.js
+++ b/__tests__/BuildingDetail.test.js
@@ -1,0 +1,24 @@
+import {buyGPU, upgradeCooling, createBuilding} from '../src/utils/gameActions';
+import SIZE_PRESETS from '../src/constants/sizePresets';
+
+describe('building actions', () => {
+  function createState() {
+    const building = createBuilding(SIZE_PRESETS[0]);
+    return {money: 10000, buildings: [building]};
+  }
+
+  it('buys a GPU when possible', () => {
+    const state = createState();
+    const newState = buyGPU(state, 0);
+    expect(newState.buildings[0].gpus).toBe(1);
+    expect(newState.buildings[0].incomePerTick).toBe(1);
+    expect(newState.money).toBe(state.money - state.buildings[0].gpuCost);
+  });
+
+  it('upgrades cooling when affordable', () => {
+    const state = createState();
+    const newState = upgradeCooling(state, 0);
+    expect(newState.buildings[0].cooling.tier).toBe(1);
+    expect(newState.money).toBe(state.money - state.buildings[0].cooling.costs[0]);
+  });
+});

--- a/__tests__/sizePresets.test.js
+++ b/__tests__/sizePresets.test.js
@@ -1,0 +1,9 @@
+import SIZE_PRESETS from '../src/constants/sizePresets';
+
+describe('SIZE_PRESETS', () => {
+  it('defines four building sizes with costs', () => {
+    expect(SIZE_PRESETS).toHaveLength(4);
+    expect(SIZE_PRESETS[0]).toMatchObject({label: 'Small (10 racks)', capacity: 10});
+    expect(SIZE_PRESETS[3]).toMatchObject({label: 'Mega (10k racks)', capacity: 10000});
+  });
+});

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['module:metro-react-native-babel-preset', '@babel/preset-typescript'],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'react-native',
+  transformIgnorePatterns: [
+    'node_modules/(?!(react-native|@react-native|@react-native-community|@testing-library|@expo|expo-.*)/)'
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -2,5 +2,17 @@
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
     "react-native-paper": "4.9.2"
+  },
+  "devDependencies": {
+    "@babel/preset-typescript": "^7.27.1",
+    "@testing-library/jest-native": "^5.4.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/react-native": "^13.2.0",
+    "jest": "^30.0.4",
+    "metro-react-native-babel-preset": "^0.77.0",
+    "react-test-renderer": "^19.1.0"
+  },
+  "scripts": {
+    "test": "jest"
   }
 }

--- a/src/components/AddBuildingButton.js
+++ b/src/components/AddBuildingButton.js
@@ -2,6 +2,7 @@ import React, {useState} from 'react';
 import {View, TouchableOpacity, Text, StyleSheet} from 'react-native';
 import {useGame} from '../context/GameContext';
 import SIZE_PRESETS from '../constants/sizePresets';
+import {addBuilding} from '../utils/gameActions';
 
 export default function AddBuildingButton() {
   const {state, setState} = useGame();
@@ -9,22 +10,7 @@ export default function AddBuildingButton() {
 
   const add = preset => {
     if (state.money >= preset.purchaseCost) {
-      const newB = {
-        size: preset,
-        gpus: 0,
-        gpuCost: 100 * Math.pow(2, preset.costMultiplier),
-        gpuIncome: 1,
-        incomePerTick: 0,
-        cooling: {
-          tier: 0,
-          costs: [
-            500 * preset.costMultiplier,
-            2000 * preset.costMultiplier,
-            10000 * preset.costMultiplier,
-          ],
-        },
-      };
-      setState(s => ({...s, money: s.money - preset.purchaseCost, buildings: [...s.buildings, newB]}));
+      setState(s => addBuilding(s, preset));
       setShowOptions(false);
     }
   };

--- a/src/components/BuildingDetail.js
+++ b/src/components/BuildingDetail.js
@@ -1,27 +1,18 @@
 import React from 'react';
 import {View, Text, TouchableOpacity, StyleSheet} from 'react-native';
 import {useGame} from '../context/GameContext';
+import {buyGPU as buyGPUAction, upgradeCooling as upgradeCoolingAction} from '../utils/gameActions';
 
 export default function BuildingDetail({index, goBack}) {
   const {state, setState} = useGame();
   const b = state.buildings[index];
 
   const buyGPU = () => {
-    if (state.money >= b.gpuCost && b.gpus < b.size.capacity) {
-      const updated = [...state.buildings];
-      updated[index].gpus += 1;
-      updated[index].incomePerTick += b.gpuIncome;
-      setState(s => ({...s, money: s.money - b.gpuCost, buildings: updated}));
-    }
+    setState(s => buyGPUAction(s, index));
   };
 
   const upgradeCooling = () => {
-    const {tier, costs} = b.cooling;
-    if (tier < costs.length - 1 && state.money >= costs[tier]) {
-      const updated = [...state.buildings];
-      updated[index].cooling.tier += 1;
-      setState(s => ({...s, money: s.money - costs[tier], buildings: updated}));
-    }
+    setState(s => upgradeCoolingAction(s, index));
   };
 
   return (

--- a/src/utils/gameActions.js
+++ b/src/utils/gameActions.js
@@ -1,0 +1,64 @@
+export function createBuilding(preset) {
+  return {
+    size: preset,
+    gpus: 0,
+    gpuCost: 100 * Math.pow(2, preset.costMultiplier),
+    gpuIncome: 1,
+    incomePerTick: 0,
+    cooling: {
+      tier: 0,
+      costs: [
+        500 * preset.costMultiplier,
+        2000 * preset.costMultiplier,
+        10000 * preset.costMultiplier,
+      ],
+    },
+  };
+}
+
+export function addBuilding(state, preset) {
+  if (state.money < preset.purchaseCost) return state;
+  const newB = createBuilding(preset);
+  return {
+    ...state,
+    money: state.money - preset.purchaseCost,
+    buildings: [...state.buildings, newB],
+  };
+}
+
+export function buyGPU(state, index) {
+  const building = state.buildings[index];
+  if (!building) return state;
+  if (state.money < building.gpuCost || building.gpus >= building.size.capacity) return state;
+  const updated = [...state.buildings];
+  updated[index] = {
+    ...building,
+    gpus: building.gpus + 1,
+    incomePerTick: building.incomePerTick + building.gpuIncome,
+  };
+  return {
+    ...state,
+    money: state.money - building.gpuCost,
+    buildings: updated,
+  };
+}
+
+export function upgradeCooling(state, index) {
+  const building = state.buildings[index];
+  if (!building) return state;
+  const {tier, costs} = building.cooling;
+  if (tier >= costs.length - 1 || state.money < costs[tier]) return state;
+  const updated = [...state.buildings];
+  updated[index] = {
+    ...building,
+    cooling: {
+      ...building.cooling,
+      tier: tier + 1,
+    },
+  };
+  return {
+    ...state,
+    money: state.money - costs[tier],
+    buildings: updated,
+  };
+}


### PR DESCRIPTION
## Summary
- add jest configuration and babel preset
- provide pure gameActions for game logic
- wire components to use the new utilities
- create unit tests for business logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68733b21e43483318534c82ee06c346c