### PR TITLE
Add cooling and throttling system

### DIFF
--- a/App.js
+++ b/App.js
@@ -6,6 +6,7 @@ import GPU_TYPES from './src/constants/gpuTypes';
 import BuildingItem from './src/components/BuildingItem';
 import BuildingDetail from './src/components/BuildingDetail';
 import AddBuildingButton from './src/components/AddBuildingButton';
+import {tick} from './src/utils/simEngine';
 
 const initialState = {
   money: SIZE_PRESETS[0].purchaseCost + 2 * GPU_TYPES[0].cost,
@@ -18,19 +19,10 @@ export default function App() {
 
   useEffect(() => {
     const interval = setInterval(() => {
-      const income = state.buildings.reduce((sum, b) => {
-        return (
-          sum +
-          b.gpuCounts.reduce(
-            (iSum, count, idx) => iSum + count * GPU_TYPES[idx].income,
-            0,
-          )
-        );
-      }, 0);
-      setState(s => ({...s, money: s.money + income}));
+      setState(s => tick(s));
     }, 1000);
     return () => clearInterval(interval);
-  }, [state.buildings]);
+  }, []);
 
   const goBack = () => setSelectedBuilding(null);
 

--- a/__tests__/simEngine.test.js
+++ b/__tests__/simEngine.test.js
@@ -1,0 +1,31 @@
+import {computePerformanceMultiplier, tick} from '../src/utils/simEngine';
+import {createBuilding} from '../src/utils/gameActions';
+import SIZE_PRESETS from '../src/constants/sizePresets';
+import GPU_TYPES from '../src/constants/gpuTypes';
+
+describe('cooling & throttling system', () => {
+  test('performance multiplier thresholds', () => {
+    expect(computePerformanceMultiplier(10, 10)).toBe(1);
+    expect(computePerformanceMultiplier(11, 10)).toBe(0.5);
+    expect(computePerformanceMultiplier(20, 10)).toBe(0.5);
+    expect(computePerformanceMultiplier(21, 10)).toBe(0.25);
+  });
+
+  test('tick integration with heat buildup', () => {
+    const b = createBuilding(SIZE_PRESETS[0]);
+    // give 20 basic gpus
+    b.gpuCounts[0] = 20;
+    const state = {money: 0, buildings: [b]};
+
+    let s = tick(state); // tick1
+    expect(s.money).toBeCloseTo(20);
+    expect(s.buildings[0].currentHeat).toBe(10);
+    s = tick(s); // tick2
+    expect(s.money).toBeCloseTo(30);
+    expect(s.buildings[0].currentHeat).toBe(20);
+    s = tick(s); // tick3
+    expect(s.money).toBeCloseTo(35);
+    expect(s.buildings[0].currentHeat).toBe(30);
+    expect(s.buildings[0].throttleState).toBe('Red');
+  });
+});

--- a/src/components/BuildingDetail.js
+++ b/src/components/BuildingDetail.js
@@ -32,6 +32,27 @@ export default function BuildingDetail({index, goBack}) {
         <Text style={styles.label}>Capacity:</Text>
         <Text style={styles.value}>{b.size.capacity}</Text>
       </View>
+      <View style={styles.row}>
+        <Text style={styles.label}>Status:</Text>
+        <View
+          style={[
+            styles.badge,
+            {
+              backgroundColor:
+                b.throttleState === 'Green'
+                  ? '#38D39F'
+                  : b.throttleState === 'Yellow'
+                  ? '#F5A623'
+                  : '#FF4C4C',
+            },
+          ]}>
+          <Text style={styles.badgeText}>{b.throttleState}</Text>
+        </View>
+      </View>
+      <View style={styles.row}>
+        <Text style={styles.label}>Heat:</Text>
+        <Text style={styles.value}>{b.currentHeat.toFixed(1)}</Text>
+      </View>
       {GPU_TYPES.map((t, i) => (
         <View key={i} style={styles.gpuSection}>
           <View style={styles.row}>
@@ -72,4 +93,6 @@ const styles = StyleSheet.create({
   actionButton: {backgroundColor: '#007AFF', padding: 12, borderRadius: 8, alignItems: 'center', marginVertical: 8},
   coolButton: {backgroundColor: '#FF9500'},
   buttonText: {color: '#FFF', fontSize: 16, fontWeight: '600'},
+  badge: {borderRadius: 8, paddingHorizontal: 8, paddingVertical: 4},
+  badgeText: {color: '#FFF', fontSize: 12, fontWeight: 'bold'},
 });

--- a/src/components/BuildingItem.js
+++ b/src/components/BuildingItem.js
@@ -4,7 +4,8 @@ import {useGame} from '../context/GameContext';
 
 export default function BuildingItem({building, index}) {
   const {setSelectedBuilding} = useGame();
-  const color = ['#38D39F', '#F5A623', '#FF4C4C'][building.cooling.tier] || '#38D39F';
+  const throttleColors = {Green: '#38D39F', Yellow: '#F5A623', Red: '#FF4C4C'};
+  const color = throttleColors[building.throttleState] || '#38D39F';
   const totalGpus = building.gpuCounts.reduce((sum, c) => sum + c, 0);
 
   return (
@@ -19,10 +20,14 @@ export default function BuildingItem({building, index}) {
         <Text style={styles.value}>{totalGpus}</Text>
       </View>
       <View style={styles.row}>
-        <Text style={styles.label}>Cooling:</Text>
+        <Text style={styles.label}>Status:</Text>
         <View style={[styles.badge, {backgroundColor: color}]}>
-          <Text style={styles.badgeText}>{['Evap', 'Liquid', 'Nitro'][building.cooling.tier]}</Text>
+          <Text style={styles.badgeText}>{building.throttleState}</Text>
         </View>
+      </View>
+      <View style={styles.row}>
+        <Text style={styles.label}>Heat:</Text>
+        <Text style={styles.value}>{building.currentHeat.toFixed(1)}</Text>
       </View>
     </TouchableOpacity>
   );

--- a/src/constants/coolingTiers.js
+++ b/src/constants/coolingTiers.js
@@ -1,0 +1,3 @@
+const COOLING_CAPACITY = [10, 50, 200];
+
+export default COOLING_CAPACITY;

--- a/src/constants/gpuTypes.js
+++ b/src/constants/gpuTypes.js
@@ -1,7 +1,7 @@
 const GPU_TYPES = [
-  {label: 'Basic GPU', cost: 100, income: 1},
-  {label: 'Advanced GPU', cost: 1000, income: 12},
-  {label: 'Pro GPU', cost: 10000, income: 150},
+  {label: 'Basic GPU', cost: 100, income: 1, heat: 1},
+  {label: 'Advanced GPU', cost: 1000, income: 12, heat: 5},
+  {label: 'Pro GPU', cost: 10000, income: 150, heat: 20},
 ];
 
 export default GPU_TYPES;

--- a/src/utils/gameActions.js
+++ b/src/utils/gameActions.js
@@ -12,6 +12,9 @@ export function createBuilding(preset) {
         10000 * preset.costMultiplier,
       ],
     },
+    currentHeat: 0,
+    effectiveIncome: 0,
+    throttleState: 'Green',
   };
 }
 

--- a/src/utils/simEngine.js
+++ b/src/utils/simEngine.js
@@ -1,0 +1,51 @@
+import GPU_TYPES from '../constants/gpuTypes';
+import COOLING_CAPACITY from '../constants/coolingTiers';
+
+export function computePerformanceMultiplier(currentHeat, coolingCapacity) {
+  if (currentHeat <= coolingCapacity) return 1.0;
+  if (currentHeat <= 2 * coolingCapacity) return 0.5;
+  return 0.25;
+}
+
+export function tick(state) {
+  const buildings = state.buildings.map(b => {
+    const heatGenerated = b.gpuCounts.reduce(
+      (sum, count, i) => sum + count * GPU_TYPES[i].heat,
+      0,
+    );
+
+    let currentHeat = b.currentHeat + heatGenerated;
+
+    const coolingCapacity = COOLING_CAPACITY[b.cooling.tier] || 0;
+    const heatDissipated = Math.min(currentHeat, coolingCapacity);
+    currentHeat = Math.max(0, currentHeat - heatDissipated);
+
+    const performanceMultiplier = computePerformanceMultiplier(
+      currentHeat,
+      coolingCapacity,
+    );
+
+    const baseIncome = b.gpuCounts.reduce(
+      (sum, count, i) => sum + count * GPU_TYPES[i].income,
+      0,
+    );
+    const effectiveIncome = baseIncome * performanceMultiplier;
+
+    return {
+      ...b,
+      currentHeat,
+      effectiveIncome,
+      throttleState:
+        performanceMultiplier === 1
+          ? 'Green'
+          : performanceMultiplier === 0.5
+          ? 'Yellow'
+          : 'Red',
+    };
+  });
+
+  const money =
+    state.money + buildings.reduce((sum, b) => sum + b.effectiveIncome, 0);
+
+  return {...state, money, buildings};
+}


### PR DESCRIPTION
## Summary
- integrate heat generation, cooling capacity and throttling in the sim engine
- persist heat/throttle info per building and show it in the UI
- add simulation engine and unit tests for performance multiplier and tick logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68733ee8fff083318296130f9c83e996