### PR TITLE
Fix thermal throttling calculation

### DIFF
--- a/__tests__/simEngine.test.js
+++ b/__tests__/simEngine.test.js
@@ -18,14 +18,25 @@ describe('cooling & throttling system', () => {
     const state = {money: 0, buildings: [b]};
 
     let s = tick(state); // tick1
-    expect(s.money).toBeCloseTo(20);
+    expect(s.money).toBeCloseTo(10);
     expect(s.buildings[0].currentHeat).toBe(10);
+    expect(s.buildings[0].throttleState).toBe('Yellow');
     s = tick(s); // tick2
-    expect(s.money).toBeCloseTo(30);
+    expect(s.money).toBeCloseTo(15);
     expect(s.buildings[0].currentHeat).toBe(20);
+    expect(s.buildings[0].throttleState).toBe('Red');
     s = tick(s); // tick3
-    expect(s.money).toBeCloseTo(35);
+    expect(s.money).toBeCloseTo(20);
     expect(s.buildings[0].currentHeat).toBe(30);
     expect(s.buildings[0].throttleState).toBe('Red');
+  });
+
+  test('immediate throttling when heat exceeds capacity', () => {
+    const b = createBuilding(SIZE_PRESETS[0]);
+    b.gpuCounts[0] = 15; // generates 15 heat per tick
+    const state = {money: 0, buildings: [b]};
+
+    const s = tick(state);
+    expect(s.buildings[0].throttleState).toBe('Yellow');
   });
 });

--- a/src/utils/simEngine.js
+++ b/src/utils/simEngine.js
@@ -14,16 +14,15 @@ export function tick(state) {
       0,
     );
 
-    let currentHeat = b.currentHeat + heatGenerated;
-
     const coolingCapacity = COOLING_CAPACITY[b.cooling.tier] || 0;
-    const heatDissipated = Math.min(currentHeat, coolingCapacity);
-    currentHeat = Math.max(0, currentHeat - heatDissipated);
 
+    const preCoolingHeat = b.currentHeat + heatGenerated;
     const performanceMultiplier = computePerformanceMultiplier(
-      currentHeat,
+      preCoolingHeat,
       coolingCapacity,
     );
+
+    const currentHeat = Math.max(0, preCoolingHeat - coolingCapacity);
 
     const baseIncome = b.gpuCounts.reduce(
       (sum, count, i) => sum + count * GPU_TYPES[i].income,


### PR DESCRIPTION
## Summary
- compute throttling based on heat before cooling
- update thermal tick test
- add regression test for immediate throttling when heat exceeds capacity

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6873409b5e088331850745fac5ff820a