### PR TITLE
Implement power consumption & tiers

### DIFF
--- a/__tests__/powerCost.test.js
+++ b/__tests__/powerCost.test.js
@@ -1,0 +1,16 @@
+import {computePowerCost} from '../src/utils/simEngine';
+
+describe('computePowerCost', () => {
+  it('costs zero when usage is zero', () => {
+    expect(computePowerCost(0, 50, 0.05)).toBeCloseTo(0);
+  });
+
+  it('charges standard rate up to capacity', () => {
+    expect(computePowerCost(40, 50, 0.05)).toBeCloseTo(2);
+  });
+
+  it('double charges above capacity', () => {
+    // 60 used with 50 capacity -> 50*0.05 + 10*0.1 = 3.5
+    expect(computePowerCost(60, 50, 0.05)).toBeCloseTo(3.5);
+  });
+});

--- a/__tests__/powerUpgrade.test.js
+++ b/__tests__/powerUpgrade.test.js
@@ -1,0 +1,19 @@
+import {createBuilding, upgradePower, downgradePower} from '../src/utils/gameActions';
+import SIZE_PRESETS from '../src/constants/sizePresets';
+import POWER_TIERS from '../src/constants/powerTiers';
+
+describe('power upgrade flows', () => {
+  it('upgrades and downgrades power tiers with cost adjustments', () => {
+    const b = createBuilding(SIZE_PRESETS[0]);
+    const state = {money: 100000, buildings: [b]};
+    // upgrade to tier 1 -> cost purchaseCost[1]
+    let s = upgradePower(state, 0);
+    expect(s.buildings[0].power.tier).toBe(1);
+    expect(s.money).toBe(state.money - POWER_TIERS[1].purchaseCost);
+
+    // downgrade back -> refund half of tier1 cost
+    s = downgradePower(s, 0);
+    expect(s.buildings[0].power.tier).toBe(0);
+    expect(s.money).toBeCloseTo(state.money - POWER_TIERS[1].purchaseCost + POWER_TIERS[1].purchaseCost / 2);
+  });
+});

--- a/__tests__/simEngine.test.js
+++ b/__tests__/simEngine.test.js
@@ -1,4 +1,8 @@
-import {computePerformanceMultiplier, tick} from '../src/utils/simEngine';
+import {
+  computePerformanceMultiplier,
+  computePowerCost,
+  tick,
+} from '../src/utils/simEngine';
 import {createBuilding} from '../src/utils/gameActions';
 import SIZE_PRESETS from '../src/constants/sizePresets';
 import GPU_TYPES from '../src/constants/gpuTypes';
@@ -18,15 +22,15 @@ describe('cooling & throttling system', () => {
     const state = {money: 0, buildings: [b]};
 
     let s = tick(state); // tick1
-    expect(s.money).toBeCloseTo(10);
+    expect(s.money).toBeCloseTo(9);
     expect(s.buildings[0].currentHeat).toBe(10);
     expect(s.buildings[0].throttleState).toBe('Yellow');
     s = tick(s); // tick2
-    expect(s.money).toBeCloseTo(15);
+    expect(s.money).toBeCloseTo(13);
     expect(s.buildings[0].currentHeat).toBe(20);
     expect(s.buildings[0].throttleState).toBe('Red');
     s = tick(s); // tick3
-    expect(s.money).toBeCloseTo(20);
+    expect(s.money).toBeCloseTo(17);
     expect(s.buildings[0].currentHeat).toBe(30);
     expect(s.buildings[0].throttleState).toBe('Red');
   });

--- a/src/components/BuildingDetail.js
+++ b/src/components/BuildingDetail.js
@@ -3,10 +3,13 @@ import {View, Text, TouchableOpacity, StyleSheet, ScrollView, useColorScheme} fr
 import {useGame} from '../context/GameContext';
 import GPU_TYPES from '../constants/gpuTypes';
 import {palette, accent} from '../constants/theme';
+import POWER_TIERS from '../constants/powerTiers';
 import {
   buyGPU as buyGPUAction,
   sellGPU as sellGPUAction,
   upgradeCooling as upgradeCoolingAction,
+  upgradePower as upgradePowerAction,
+  downgradePower as downgradePowerAction,
 } from '../utils/gameActions';
 
 export default function BuildingDetail({index, goBack}) {
@@ -26,6 +29,14 @@ export default function BuildingDetail({index, goBack}) {
 
   const upgradeCooling = () => {
     setState(s => upgradeCoolingAction(s, index));
+  };
+
+  const upgradePower = () => {
+    setState(s => upgradePowerAction(s, index));
+  };
+
+  const downgradePower = () => {
+    setState(s => downgradePowerAction(s, index));
   };
 
   const earnings = b.gpuCounts.reduce(
@@ -72,6 +83,18 @@ export default function BuildingDetail({index, goBack}) {
         <Text style={styles.label}>Heat:</Text>
         <Text style={styles.value}>{b.currentHeat.toFixed(1)}</Text>
       </View>
+      <View style={styles.row}>
+        <Text style={styles.label}>Power Draw:</Text>
+        <Text style={styles.value}>{b.currentPowerDraw.toFixed(1)} kW/s</Text>
+      </View>
+      <View style={styles.row}>
+        <Text style={styles.label}>Power Cost:</Text>
+        <Text style={styles.value}>${b.currentPowerCost.toFixed(2)}/s</Text>
+      </View>
+      <View style={styles.row}>
+        <Text style={styles.label}>Tier:</Text>
+        <Text style={styles.value}>{POWER_TIERS[b.power.tier].label}</Text>
+      </View>
       {GPU_TYPES.map((t, i) => (
         <View key={i} style={styles.gpuSection}>
           <View style={styles.row}>
@@ -99,6 +122,21 @@ export default function BuildingDetail({index, goBack}) {
         style={[styles.actionButton, styles.coolButton]}>
         <Text style={styles.buttonText}>
           Upgrade Cooling (${b.cooling.costs[b.cooling.tier]})
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        onPress={upgradePower}
+        style={[styles.actionButton, styles.coolButton]}>
+        <Text style={styles.buttonText}>
+          Upgrade Power (${POWER_TIERS[b.power.tier + 1] ? POWER_TIERS[b.power.tier + 1].purchaseCost : 'MAX'})
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        onPress={downgradePower}
+        style={[styles.actionButton, styles.sellButton]}
+        disabled={b.power.tier === 0}>
+        <Text style={styles.buttonText}>
+          Downgrade Power (+${POWER_TIERS[b.power.tier].purchaseCost / 2})
         </Text>
       </TouchableOpacity>
     </ScrollView>

--- a/src/components/BuildingItem.js
+++ b/src/components/BuildingItem.js
@@ -39,6 +39,13 @@ export default function BuildingItem({building, index}) {
         <Text style={styles.label}>Heat:</Text>
         <Text style={styles.value}>{building.currentHeat.toFixed(1)}</Text>
       </View>
+      <View style={styles.row}>
+        <Text style={styles.label}>Power:</Text>
+        <Text style={styles.value}>
+          {building.currentPowerDraw.toFixed(1)} kW @{' '}
+          {building.power.tier + 1}
+        </Text>
+      </View>
     </TouchableOpacity>
   );
 }

--- a/src/constants/gpuTypes.js
+++ b/src/constants/gpuTypes.js
@@ -1,7 +1,7 @@
 const GPU_TYPES = [
-  {label: 'Basic GPU', cost: 100, income: 1, heat: 1},
-  {label: 'Advanced GPU', cost: 1000, income: 12, heat: 5},
-  {label: 'Pro GPU', cost: 10000, income: 150, heat: 20},
+  {label: 'Basic GPU', cost: 100, income: 1, heat: 1, power: 1},
+  {label: 'Advanced GPU', cost: 1000, income: 12, heat: 5, power: 5},
+  {label: 'Pro GPU', cost: 10000, income: 150, heat: 20, power: 20},
 ];
 
 export default GPU_TYPES;

--- a/src/constants/powerTiers.js
+++ b/src/constants/powerTiers.js
@@ -1,0 +1,8 @@
+const POWER_TIERS = [
+  {label: 'Diesel Generator', capacity: 50, costPerUnit: 0.05, purchaseCost: 2000},
+  {label: 'Electric Grid', capacity: 200, costPerUnit: 0.02, purchaseCost: 5000},
+  {label: 'Solar Array', capacity: 30, costPerUnit: 0.0, purchaseCost: 10000},
+  {label: 'Nuclear Reactor', capacity: 1000, costPerUnit: 0.01, purchaseCost: 50000},
+];
+
+export default POWER_TIERS;

--- a/src/utils/gameActions.js
+++ b/src/utils/gameActions.js
@@ -1,4 +1,5 @@
 import GPU_TYPES from '../constants/gpuTypes';
+import POWER_TIERS from '../constants/powerTiers';
 
 export function createBuilding(preset) {
   return {
@@ -15,6 +16,9 @@ export function createBuilding(preset) {
     currentHeat: 0,
     effectiveIncome: 0,
     throttleState: 'Green',
+    power: {tier: 0},
+    currentPowerDraw: 0,
+    currentPowerCost: 0,
   };
 }
 
@@ -83,6 +87,43 @@ export function upgradeCooling(state, index) {
   return {
     ...state,
     money: state.money - costs[tier],
+    buildings: updated,
+  };
+}
+
+export function upgradePower(state, index) {
+  const building = state.buildings[index];
+  if (!building) return state;
+  const tier = building.power.tier;
+  if (tier >= POWER_TIERS.length - 1) return state;
+  const nextCost = POWER_TIERS[tier + 1].purchaseCost;
+  if (state.money < nextCost) return state;
+  const updated = [...state.buildings];
+  updated[index] = {
+    ...building,
+    power: {tier: tier + 1},
+  };
+  return {
+    ...state,
+    money: state.money - nextCost,
+    buildings: updated,
+  };
+}
+
+export function downgradePower(state, index) {
+  const building = state.buildings[index];
+  if (!building) return state;
+  const tier = building.power.tier;
+  if (tier <= 0) return state;
+  const refund = POWER_TIERS[tier].purchaseCost / 2;
+  const updated = [...state.buildings];
+  updated[index] = {
+    ...building,
+    power: {tier: tier - 1},
+  };
+  return {
+    ...state,
+    money: state.money + refund,
     buildings: updated,
   };
 }

--- a/src/utils/simEngine.js
+++ b/src/utils/simEngine.js
@@ -1,10 +1,20 @@
 import GPU_TYPES from '../constants/gpuTypes';
 import COOLING_CAPACITY from '../constants/coolingTiers';
+import POWER_TIERS from '../constants/powerTiers';
 
 export function computePerformanceMultiplier(currentHeat, coolingCapacity) {
   if (currentHeat <= coolingCapacity) return 1.0;
   if (currentHeat <= 2 * coolingCapacity) return 0.5;
   return 0.25;
+}
+
+export function computePowerCost(powerUsed, capacity, costPerUnit) {
+  const billable = Math.min(powerUsed, capacity);
+  let cost = billable * costPerUnit;
+  if (powerUsed > capacity) {
+    cost += (powerUsed - capacity) * costPerUnit * 2;
+  }
+  return cost;
 }
 
 export function tick(state) {
@@ -30,10 +40,19 @@ export function tick(state) {
     );
     const effectiveIncome = baseIncome * performanceMultiplier;
 
+    const powerUsed = b.gpuCounts.reduce(
+      (sum, count, i) => sum + count * GPU_TYPES[i].power,
+      0,
+    );
+    const tier = POWER_TIERS[b.power.tier] || {capacity: 0, costPerUnit: 0};
+    const powerCost = computePowerCost(powerUsed, tier.capacity, tier.costPerUnit);
+
     return {
       ...b,
       currentHeat,
       effectiveIncome,
+      currentPowerDraw: powerUsed,
+      currentPowerCost: powerCost,
       throttleState:
         performanceMultiplier === 1
           ? 'Green'
@@ -43,8 +62,9 @@ export function tick(state) {
     };
   });
 
-  const money =
-    state.money + buildings.reduce((sum, b) => sum + b.effectiveIncome, 0);
+  const income = buildings.reduce((sum, b) => sum + b.effectiveIncome, 0);
+  const cost = buildings.reduce((sum, b) => sum + b.currentPowerCost, 0);
+  const money = state.money + income - cost;
 
   return {...state, money, buildings};
 }


### PR DESCRIPTION
## Summary
- add power tiers constant
- track GPU power usage
- compute power cost and deduct from tick
- display power metrics in building UI
- support power tier upgrade/downgrade
- test power cost calculations and flows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873bb31c67483319e86ff5a2cf192b4